### PR TITLE
Fix error with interchanged pvc to pv bounds

### DIFF
--- a/01-mysql-pvc.yml
+++ b/01-mysql-pvc.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,3 +11,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  volumeName: "mysql-persistent-storage"

--- a/02-wordpress-pvc.yml
+++ b/02-wordpress-pvc.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,3 +11,4 @@ spec:
   resources:
     requests:
       storage: 1Gi
+  volumeName: "wordpress-persistent-storage"


### PR DESCRIPTION
# Error description
If you're using the solution provided here it can come to the situation that the pvc wordpress is getting bound to the pv mysql and vice versa.
# Solution
By adding `volumeName:` you can ensure that pvc wordpress is bound to pv wordpress and pvc mysql is bound to pv mysql.